### PR TITLE
Changing the value of the wa-db-engine property to resolve issue #24

### DIFF
--- a/installation/kubernetes/db.env
+++ b/installation/kubernetes/db.env
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-wa-db-engine=MYSQL
+wa-db-engine=mysql
 wa-db-hostname=mysql-service
 wa-db-port=3306
 wa-db-username=root


### PR DESCRIPTION
Changing the value of the wa-db-engine property to lowercase to solve the problem of loading environment variables related to the ssl settings between the web application and mysql.

More information on issue https://github.com/WhatsApp/WhatsApp-Business-API-Setup-Scripts/issues/24