### PR TITLE
Include basic liveness & readiness probes

### DIFF
--- a/installation/kubernetes/webapp.yaml
+++ b/installation/kubernetes/webapp.yaml
@@ -92,6 +92,20 @@ spec:
               key: wa-db-password
         - name: WA_WEB_SERVERNAME
           value: 'whatsapp-web-service'
+        livenessProbe:
+          httpGet:
+            path: /
+            port: web
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: web
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
         volumeMounts:
         - name: whatsapp-media
           mountPath: /usr/local/wamedia


### PR DESCRIPTION
Include a HTTPS request to the root path (/) that returns a 200 OK and does not require a token to be requested.

This is important because, if the lighttpd server dies, the container keeps running and K8s never notices. You can reproduce this behavior by entering the container (e.g. kubectl exec -it xxxxx sh) and sending a kill -9 to the lighttpd process.

With this change, kubernetes notices the pod is no longer live > kill it > relaunch it and everything keeps running.