### PR TITLE
Added compatibility for Mac M1/M2 arch

### DIFF
--- a/installation/docker-compose.yml
+++ b/installation/docker-compose.yml
@@ -14,6 +14,7 @@ volumes:
 services:
   db:
     image: mysql:5.7.35
+    platform: linux/amd64
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: testpass


### PR DESCRIPTION
Context:

After trying the execution of installation/docker-compose.yml (MySQL) in ac M1 arch (arc64) we got this error:

```ERROR: no matching manifest for linux/arm64 in the manifest list entries```

Adding this line in the docker compose file the problem is solved